### PR TITLE
JSEARCH-569: Implement 'v1/labels' endpoint

### DIFF
--- a/jibrel_notable_accounts/api/database_queries.py
+++ b/jibrel_notable_accounts/api/database_queries.py
@@ -1,0 +1,22 @@
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Query
+
+from jibrel_notable_accounts.api.types import Addresses
+from jibrel_notable_accounts.common.tables import notable_accounts_t
+
+columns = [
+    notable_accounts_t.c.address,
+    notable_accounts_t.c.name,
+    notable_accounts_t.c.labels,
+]
+
+
+def select_notable_accounts(addresses: Optional[Addresses]) -> Query:
+    select_query = select(columns)
+
+    if addresses:
+        select_query = select_query.where(notable_accounts_t.c.address.in_(addresses))
+
+    return select_query

--- a/jibrel_notable_accounts/api/handlers.py
+++ b/jibrel_notable_accounts/api/handlers.py
@@ -2,14 +2,22 @@ from typing import Optional
 
 from aiohttp import web
 
-from jibrel_notable_accounts.api.serializers.labels import LabelListSchema
+from jibrel_notable_accounts.api.database_queries import select_notable_accounts
+from jibrel_notable_accounts.api.serializers.labels import LabelListQueryParams, Label
 from jibrel_notable_accounts.api.types import Addresses
 from jibrel_notable_accounts.api.utils.misc import use_kwargs
+from jibrel_notable_accounts.api.utils.response import api_success
 
 
-@use_kwargs(LabelListSchema())
+@use_kwargs(LabelListQueryParams())
 async def get_labels(
         request: web.Request,
         addresses: Optional[Addresses] = None,
 ) -> web.Response:
-    return web.json_response()
+    query = select_notable_accounts(addresses)
+    rows = await request.app['db'].fetch_all(query)
+
+    data_schema = Label()
+    data = data_schema.dump(rows, many=True)
+
+    return api_success(data=data)

--- a/jibrel_notable_accounts/api/serializers/base.py
+++ b/jibrel_notable_accounts/api/serializers/base.py
@@ -1,41 +1,74 @@
-from typing import Dict, Any, List, NoReturn
+import functools
+from typing import Dict, Any, List, NoReturn, Union
 
-from marshmallow import Schema as MarshmallowSchema
+from marshmallow import Schema
 from marshmallow import ValidationError
-from marshmallow.marshalling import SCHEMA
+from marshmallow.exceptions import SCHEMA
 
 from jibrel_notable_accounts.api.utils.api_error import ApiError
 from jibrel_notable_accounts.api.utils.error_code import ErrorCode
 
 
-class ApiErrorSchema(MarshmallowSchema):
-    def handle_error(self, exc: ValidationError, data: Dict[str, Any]) -> None:
-        convert_to_api_error_and_raise(exc)
+class ApiErrorSchema(Schema):
+    def handle_error(self, error: ValidationError, data: Dict[str, Any], *, many: bool, **kwargs: Any) -> NoReturn:
+        convert_to_api_error_and_raise(error)
 
 
 def convert_to_api_error_and_raise(exc: ValidationError) -> NoReturn:
     raise ApiError(errors=get_flatten_error_messages(exc.messages), status=400)
 
 
-def get_flatten_error_messages(messages: Dict[str, List[str]]) -> List[Dict[str, str]]:
+def get_flatten_error_messages(messages: Union[List[Any], Dict[Any, Any]]) -> List[Dict[str, str]]:
+    """
+    >>> get_flatten_error_messages(['Whole schema is bad.']) == [
+    ...     {'field': '__all__', 'message': 'Whole schema is bad.', 'code': 'VALIDATION_ERROR'}
+    ... ]
+    True
+    >>> get_flatten_error_messages({'_schema': ['Everything is bad.']}) == [
+    ...     {'field': '__all__', 'message': 'Everything is bad.', 'code': 'VALIDATION_ERROR'}
+    ... ]
+    True
+    >>> get_flatten_error_messages({'value': ['Not a valid value.']}) == [
+    ...     {'field': 'value', 'message': 'Not a valid value.', 'code': 'INVALID_VALUE'}
+    ... ]
+    True
+    >>> get_flatten_error_messages({'f': {0: ['One.', 'Error.'], 1: ['Another.', 'Error.']}}) == [
+    ...     {'field': 'f', 'message': 'One.', 'code': 'INVALID_VALUE'},
+    ...     {'field': 'f', 'message': 'Error.', 'code': 'INVALID_VALUE'},
+    ...     {'field': 'f', 'message': 'Another.', 'code': 'INVALID_VALUE'},
+    ...     {'field': 'f', 'message': 'Error.', 'code': 'INVALID_VALUE'},
+    ... ]
+    True
+    >>> get_flatten_error_messages({'field_with_multiple_errors': ['Error one.', 'Error two.']}) == [
+    ...     {'field': 'field_with_multiple_errors', 'message': 'Error one.', 'code': 'INVALID_VALUE'},
+    ...     {'field': 'field_with_multiple_errors', 'message': 'Error two.', 'code': 'INVALID_VALUE'},
+    ... ]
+    True
+    """
+    if isinstance(messages, list):
+        return [{'field': '__all__', 'message': msg, 'code': ErrorCode.VALIDATION_ERROR} for msg in messages]
+
     flatten_messages = []
 
     for field, msgs in messages.items():
+        if isinstance(msgs, dict):
+            msgs = functools.reduce(lambda x, y: x + y, msgs.values(), [])
+
         for msg in msgs:
-            message = {'field': get_field(field), 'message': msg, 'code': get_error_code(field)}
+            message = {'field': _get_field(field), 'message': msg, 'code': _get_error_code(field)}
             flatten_messages.append(message)
 
     return flatten_messages
 
 
-def get_field(field: str) -> str:
+def _get_field(field: str) -> str:
     if field == SCHEMA:
         return '__all__'
 
     return field
 
 
-def get_error_code(field: str) -> str:
+def _get_error_code(field: str) -> str:
     if field == SCHEMA:
         return ErrorCode.VALIDATION_ERROR
 

--- a/jibrel_notable_accounts/api/serializers/labels.py
+++ b/jibrel_notable_accounts/api/serializers/labels.py
@@ -1,7 +1,28 @@
-from marshmallow.fields import List, Str
+from typing import Dict, Any, Iterable
+
+import webargs.fields
+from marshmallow import fields, post_dump
 
 from jibrel_notable_accounts.api.serializers.base import ApiErrorSchema
 
 
-class LabelListSchema(ApiErrorSchema):
-    addresses = List(Str())
+class LabelListQueryParams(ApiErrorSchema):
+    addresses = webargs.fields.DelimitedList(fields.Str(), load_from='address')
+
+
+class Label(ApiErrorSchema):
+    name = fields.Str()
+    address = fields.Str()
+    labels = fields.List(fields.Str())
+
+    @post_dump(pass_many=True)
+    def convert_to_dict(self, data: Iterable[Dict[str, Any]], **kwargs: Any) -> Dict[str, Any]:
+        converted = dict()
+
+        for item in data:
+            converted[item['address']] = {
+                'name': item['name'],
+                'labels': item['labels'],
+            }
+
+        return converted

--- a/jibrel_notable_accounts/tests/plugins/misc.py
+++ b/jibrel_notable_accounts/tests/plugins/misc.py
@@ -10,6 +10,7 @@ from jibrel_notable_accounts import settings
 from pytest_mock import MockFixture
 
 from jibrel_notable_accounts.api.app import make_app
+from jibrel_notable_accounts.common import logs
 from jibrel_notable_accounts.parser.app import make_app as make_parser_app
 from typing import Any, AsyncGenerator, Generator
 
@@ -101,3 +102,8 @@ def disable_metrics_setup(mocker: MockFixture) -> None:
     # singleton. If same metric is contributed twice, `ValueError` is raised.
 
     mocker.patch.object(CollectorRegistry, 'register')
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_logs() -> None:
+    logs.configure('DEBUG', no_json_formatter=True)

--- a/jibrel_notable_accounts/tests/test_api.py
+++ b/jibrel_notable_accounts/tests/test_api.py
@@ -1,0 +1,95 @@
+from aiohttp.test_utils import TestClient
+from aiopg.sa import Engine
+
+from jibrel_notable_accounts.common.tables import notable_accounts_t
+
+
+async def test_get_labels_returns_all_available_entries_in_db_if_addresses_are_not_specified(
+        cli: TestClient,
+        sa_engine: Engine,
+) -> None:
+    async with sa_engine.acquire() as conn:
+        await conn.execute(notable_accounts_t.insert().values(
+            {
+                'address': '0x8da0d80f5007ef1e431dd2127178d224e32c2ef4',
+                'name': '0x: Token Transfer Proxy',
+                'labels': ['0x Ecosystem'],
+            },
+        ))
+        await conn.execute(notable_accounts_t.insert().values(
+            {
+                'address': '0x3f5CE5FBFe3E9af3971dD833D26bA9b5C936f0bE',
+                'name': 'Binance 1',
+                'labels': ['Binance', 'Exchange'],
+            },
+        ))
+
+    response = await cli.get('/v1/labels')
+    response_json = await response.json()
+
+    assert response_json == {
+        'status': {
+            'success': True,
+            'errors': [],
+        },
+        'data': {
+            '0x8da0d80f5007ef1e431dd2127178d224e32c2ef4': {
+                'name': '0x: Token Transfer Proxy',
+                'labels': ['0x Ecosystem'],
+            },
+            '0x3f5CE5FBFe3E9af3971dD833D26bA9b5C936f0bE': {
+                'name': 'Binance 1',
+                'labels': ['Binance', 'Exchange'],
+            },
+        }
+    }
+
+
+async def test_get_labels_returns_selected_entries_in_db_if_addresses_are_specified(
+        cli: TestClient,
+        sa_engine: Engine,
+) -> None:
+    async with sa_engine.acquire() as conn:
+        await conn.execute(notable_accounts_t.insert().values(
+            {
+                'address': '0x8da0d80f5007ef1e431dd2127178d224e32c2ef4',
+                'name': '0x: Token Transfer Proxy',
+                'labels': ['0x Ecosystem'],
+            },
+        ))
+        await conn.execute(notable_accounts_t.insert().values(
+            {
+                'address': '0x3f5CE5FBFe3E9af3971dD833D26bA9b5C936f0bE',
+                'name': 'Binance 1',
+                'labels': ['Binance', 'Exchange'],
+            },
+        ))
+        await conn.execute(notable_accounts_t.insert().values(
+            {
+                'address': '0xfE9e8709d3215310075d67E3ed32A380CCf451C8',
+                'name': 'Binance 5',
+                'labels': ['Binance', 'Exchange'],
+            },
+        ))
+
+    response = await cli.get(
+        '/v1/labels?addresses=0x8da0d80f5007ef1e431dd2127178d224e32c2ef4,0xfE9e8709d3215310075d67E3ed32A380CCf451C8'
+    )
+    response_json = await response.json()
+
+    assert response_json == {
+        'status': {
+            'success': True,
+            'errors': [],
+        },
+        'data': {
+            '0x8da0d80f5007ef1e431dd2127178d224e32c2ef4': {
+                'name': '0x: Token Transfer Proxy',
+                'labels': ['0x Ecosystem'],
+            },
+            '0xfE9e8709d3215310075d67E3ed32A380CCf451C8': {
+                'name': 'Binance 5',
+                'labels': ['Binance', 'Exchange'],
+            },
+        }
+    }

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ cssselect
 dsnparse==0.1.12
 gunicorn==19.9.0
 lxml==4.2.1
-marshmallow==2.19.5
+marshmallow==3.1.1
 mode==4.0.1
 prometheus-client==0.7.1
 psycopg2-binary==2.8.3
@@ -16,4 +16,4 @@ python-json-logger==0.1.11
 requests==2.18.4
 sentry-sdk==0.5.2
 sqlalchemy==1.3.6
-webargs==5.3.2
+webargs==5.5.1


### PR DESCRIPTION
This PR adds `/v1/labels` endpoint by the spec described in #13:

```
GET /v1/labels?addresses=...

{  
  "status": {
    "success": True,
    "errors": [],
  },
  "data": {
    "0x8da0d80f5007ef1e431dd2127178d224e32c2ef4": {
      "name": "0x: Token Transfer Proxy",
      "labels": ["0x Ecosystem"],
    },
    "0x3f5CE5FBFe3E9af3971dD833D26bA9b5C936f0bE": {
      "name": "Binance 1",
      "labels": ["Binance", "Exchange"],
    },
  }
}
```